### PR TITLE
Handle real time in the generic judge

### DIFF
--- a/judges/generic/judge.py
+++ b/judges/generic/judge.py
@@ -17,6 +17,7 @@ def judge(args):
     compile_time = parse_time(args.test.get('compile_time', '10s'))
     cpp_standard = args.test.get('cpp_standard', 'c++17')
     time_limit = parse_time(args.test.get('time', '10s'))
+    real_time_limit = parse_time(args.test.get('real_time', '10s'))
     memory_limit = parse_memory(args.test.get('memory', '1G'))
     args.add_steps(
         system=SystemPrepareTask(default_logs=False),
@@ -43,6 +44,7 @@ def judge(args):
         checker_source=args.test.get('checker', None),
         limit_cores=1,
         limit_time=time_limit,
+        limit_real_time=real_time_limit,
         limit_memory=memory_limit,
         )
     )

--- a/kolejka/judge/tasks/io.py
+++ b/kolejka/judge/tasks/io.py
@@ -44,14 +44,8 @@ class IOTask(TaskBase):
         self.hinter_output_path = hinter_output_path
         self.checker_source = checker_source
         self.limit_cores = limit_cores
-        self.limit_cpu_time = limit_time
-        self.limit_real_time = None
-        if limit_time is not None:
-            self.limit_real_time = parse_time(limit_time) + parse_time('1s')
-        if limit_cpu_time is not None:
-            self.limit_cpu_time = limit_cpu_time
-        if limit_real_time is not None:
-            self.limit_real_time = limit_real_time
+        self.limit_cpu_time = limit_cpu_time or limit_time
+        self.limit_real_time = limit_real_time or (parse_time(limit_time) + parse_time('1s') if limit_time else None)
         self.limit_memory = limit_memory
         self.limit_gpu_memory = limit_gpu_memory
         self.case_sensitive = case_sensitive


### PR DESCRIPTION
Add `real_time` flag in the generic judge and simplify setting cpu and real time limits